### PR TITLE
Fix edge detection variable order

### DIFF
--- a/SE2-IMGtoGame.py
+++ b/SE2-IMGtoGame.py
@@ -537,7 +537,7 @@ class PixelArtSchematicApp(ttk.Frame):
         # Se nenhum tipo for permitido, NÃO usamos fallback – retornamos blocos vazios.
         
         # Gera os blocos usando somente os tipos permitidos.
-        self.blocks, small_px, new_width, new_height, num_cols, num_rows, inside = generate_blocks_with_allowed(
+        self.blocks, small_px, new_width, new_height, num_rows, num_cols, inside = generate_blocks_with_allowed(
             self.image_pil, scale, allowed, threshold=30.0, debug=self.debug_var.get())
         if not self.blocks:
             messagebox.showinfo(self.strings["warning"], "Nenhum bloco gerado (possivelmente nenhum tipo permitido).")
@@ -549,7 +549,7 @@ class PixelArtSchematicApp(ttk.Frame):
                 r0 = block["row_start"]
                 c0 = block["col_start"]
                 size = block["cell_size"]
-                if r0 == 0 or c0 == 0 or (r0 + size) >= num_rows or (c0 + size) >= num_rows:
+                if r0 == 0 or c0 == 0 or (r0 + size) >= num_rows or (c0 + size) >= num_cols:
                     return True
                 for i in range(r0, r0 + size):
                     for j in range(c0, c0 + size):


### PR DESCRIPTION
## Summary
- fix swapped `num_rows` and `num_cols` when generating blocks
- use correct column limit for edge block detection

## Testing
- `python3 -m py_compile SE2-IMGtoGame.py`
- `python3 SE2-IMGtoGame.py` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68493c2238a4833194142dda9c21b99f